### PR TITLE
Reexport missing ProjectSnippet and ProjectBadges

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ PipelineSchedules
 PipelineScheduleVariables
 Projects
 ProjectAccessRequests
+ProjectBadges
 ProjectCustomAttributes
 ProjectImportExport
 ProjectIssueBoards
@@ -205,6 +206,7 @@ PipelineSchedules
 PipelineScheduleVariables
 Projects
 ProjectAccessRequests
+ProjectBadges
 ProjectCustomAttributes
 ProjectImportExport
 ProjectIssueBoards

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,7 @@ export const ProjectsBundle = Bundler(Pick(APIServices, [
   'ProjectHooks',
   'ProjectMembers',
   'ProjectMilestones',
-  'ProjectSnippet',
+  'ProjectSnippets',
   'ProjectSnippetNotes',
   'ProjectSnippetDiscussions',
   'ProjectSnippetAwardEmojis',

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -41,6 +41,7 @@ export PipelineSchedules from './PipelineSchedules';
 export PipelineScheduleVariables from './PipelineScheduleVariables';
 export Projects from './Projects';
 export ProjectAccessRequests from './ProjectAccessRequests';
+export ProjectBadges from './ProjectBadges';
 export ProjectCustomAttributes from './ProjectCustomAttributes';
 export ProjectImportExport from './ProjectImportExport';
 export ProjectIssueBoards from './ProjectIssueBoards';


### PR DESCRIPTION
I started typescript introduction and fist problem I've discovered is missing exports.

`ProjectBadges` was empty because of lost re-export in `services/index.js` and `ProjectSnippets` was empty because it was re-exported under wrong name (`ProjectSnippet`)