### PR TITLE
feat: obey the rate limit

### DIFF
--- a/src/infrastructure/RequestHelper.js
+++ b/src/infrastructure/RequestHelper.js
@@ -54,7 +54,11 @@ function getStream(service, endpoint, options = {}) {
   return StreamableRequest.get(requestOptions);
 }
 
-async function getPaginated(service, endpoint, options = {}) {
+async function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function getPaginated(service, endpoint, options = {}, sleepOnRateLimit = true) {
   const { showPagination, maxPages, ...queryOptions } = options;
   const requestOptions = defaultRequest(service, endpoint, {
     headers: service.headers,
@@ -62,37 +66,47 @@ async function getPaginated(service, endpoint, options = {}) {
     resolveWithFullResponse: true,
   });
 
-  const response = await service.requester.get(requestOptions);
-  const links = LinkParser(response.headers.link) || {};
-  const page = response.headers['x-page'];
-  const underMaxPageLimit = maxPages ? page < maxPages : true;
-  let more = [];
-  let data;
+  try {
+    const response = await service.requester.get(requestOptions);
+    const links = LinkParser(response.headers.link) || {};
+    const page = response.headers['x-page'];
+    const underMaxPageLimit = maxPages ? page < maxPages : true;
+    let more = [];
+    let data;
 
-  // If not looking for a singular page and still under the max pages limit
-  // AND their is a next page, paginate
-  if (!queryOptions.page && underMaxPageLimit && links.next) {
-    more = await getPaginated(service, links.next.url.replace(service.url, ''), options);
-    data = [...response.body, ...more];
-  } else {
-    data = response.body;
+    // If not looking for a singular page and still under the max pages limit
+    // AND their is a next page, paginate
+    if (!queryOptions.page && underMaxPageLimit && links.next) {
+      more = await getPaginated(service, links.next.url.replace(service.url, ''), options);
+      data = [...response.body, ...more];
+    } else {
+      data = response.body;
+    }
+
+    if (queryOptions.page && showPagination) {
+      return {
+        data,
+        pagination: {
+          total: response.headers['x-total'],
+          next: response.headers['x-next-page'] || null,
+          current: response.headers['x-page'] || null,
+          previous: response.headers['x-prev-page'] || null,
+          perPage: response.headers['x-per-page'],
+          totalPages: response.headers['x-total-pages'],
+        },
+      };
+    }
+
+    return data;
+  } catch (err) {
+    const sleepTime = parseInt(err.response.headers['retry-after'], 10);
+    if (sleepOnRateLimit && parseInt(err.statusCode, 10) === 429
+         && sleepTime) {
+      await wait(sleepTime * 1000);
+      return getPaginated(service, endpoint, options, sleepOnRateLimit);
+    }
+    throw err;
   }
-
-  if (queryOptions.page && showPagination) {
-    return {
-      data,
-      pagination: {
-        total: response.headers['x-total'],
-        next: response.headers['x-next-page'] || null,
-        current: response.headers['x-page'] || null,
-        previous: response.headers['x-prev-page'] || null,
-        perPage: response.headers['x-per-page'],
-        totalPages: response.headers['x-total-pages'],
-      },
-    };
-  }
-
-  return data;
 }
 
 class RequestHelper {


### PR DESCRIPTION
This PR enables node-gitlab to wait if the GitLab rate-limit is hit.
It waits as long as GitLab specifies via the [Retry-After header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After)

GitLab lacks documentation about this feature, but rate-limits can be set in the Admin UI (see screenshot)
and via the settings API.
![image](https://user-images.githubusercontent.com/6639323/38921537-4fb45bdc-42f6-11e8-8bf1-397dff48c7a4.png)

```json
{
 "throttle_authenticated_api_enabled": false,
 "throttle_authenticated_api_requests_per_period": 2,
 "throttle_authenticated_api_period_in_seconds": 10,
}
```
