### PR TITLE
Add Push Rule service

### DIFF
--- a/src/services/PushRule.js
+++ b/src/services/PushRule.js
@@ -1,0 +1,37 @@
+import { BaseService, RequestHelper } from '../infrastructure';
+
+class PushRule extends BaseService {
+
+  create(projectId, options) {
+    const pId = encodeURIComponent(projectId);
+
+    return RequestHelper.post(this, `projects/${pId}/push_rule`, options);
+  }
+
+  async edit(projectId, { upsert, ...options } = {}) {
+    const pId = encodeURIComponent(projectId);
+
+    if (upsert) {
+      const pushRule = await this.show(projectId);
+
+      if (!pushRule) return this.create(projectId, options)
+    }
+
+    return RequestHelper.put(this, `projects/${pId}/push_rule`, args);
+  }
+
+  remove(projectId) {
+    const pId = encodeURIComponent(projectId);
+
+    return RequestHelper.delete(this, `projects/${pId}/push_rule`);
+  }
+
+  show(projectId) {
+    const pId = encodeURIComponent(projectId);
+
+    return RequestHelper.get(this, `projects/${pId}/push_rule`);
+  }
+
+}
+
+export default PushRule;

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -63,6 +63,7 @@ export { default as Services } from './Services';
 export { default as Tags } from './Tags';
 export { default as Todos } from './Todos';
 export { default as Triggers } from './Triggers';
+export { default as PushRule } from './PushRule';
 
 // General
 export { default as ApplicationSettings } from './ApplicationSettings';

--- a/test/tests/services/PushRule.js
+++ b/test/tests/services/PushRule.js
@@ -1,0 +1,18 @@
+import { PushRule } from '../../../src';
+
+describe('PushRule', () => {
+  it('should create or edit push rule on upsert', async () => {
+    const service = new PushRule({
+      url: process.env.GITLAB_URL,
+      token: process.env.PERSONAL_ACCESS_TOKEN,
+    });
+    const pushRules = {
+      upsert: true,
+      member_check: true
+    }
+    const result = await service.edit(1, pushRules);
+
+    expect(result).toBeInstanceOf(Object);
+    expect(result.member_check).toBeTrue();
+  });
+});


### PR DESCRIPTION
Love the newly added `updatePushRule` but it felt lacking when you wanted to enforce push rule for all projects and gitlab API was lacking a `createOrEdit` function and would return null with status code 404 when no push rules were created.