### PR TITLE
feat: add transfer a project to a new namespace

### DIFF
--- a/src/services/Projects.js
+++ b/src/services/Projects.js
@@ -88,6 +88,11 @@ class Projects extends BaseService {
     return RequestHelper.post(this, `projects/${pId}/statuses/${sha}`, { state, ...options });
   }
 
+  transfer(projectId, namespace) {
+    const pId = encodeURIComponent(projectId);
+    return RequestHelper.put(this, `projects/${pId}/transfer`, namespace);
+  }
+
   unshare(projectId, groupId) {
     const [pId, gId] = [projectId, groupId].map(encodeURIComponent);
 


### PR DESCRIPTION
Added in 11.1: 
https://docs.gitlab.com/ee/api/projects.html#transfer-a-project-to-a-new-namespace
https://about.gitlab.com/2018/07/22/gitlab-11-1-released/#transfer-projects-between-namespaces-via-api

The new thing is that you can transfer a project to another user or another group while the group api only allows to move to a group