### PR TITLE
Fix 'next' branch

### DIFF
--- a/src/infrastructure/RequestHelper.ts
+++ b/src/infrastructure/RequestHelper.ts
@@ -22,7 +22,7 @@ interface GetPaginatedOptions {
 
 type RequestParametersOutput = RequestParametersInput & Required<Pick<RequestParametersInput, 'url'>>;
 
-async function wait(ms) {
+export async function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 

--- a/src/infrastructure/XMLHttpRequester.ts
+++ b/src/infrastructure/XMLHttpRequester.ts
@@ -1,7 +1,7 @@
 import { StatusCodeError } from 'request-promise-core/errors';
 import Promisify from 'util.promisify';
 import XHR from 'xhr';
-import wait from './RequestHelper';
+import { wait } from './RequestHelper';
 
 function promisifyFn(fn) {
   const promisifiedFn = Promisify(fn);

--- a/src/services/MergeRequests.ts
+++ b/src/services/MergeRequests.ts
@@ -98,7 +98,7 @@ class MergeRequests extends BaseService {
     return RequestHelper.put(this, `projects/${pId}/${mergeRequest}approvers`, options);
   }
 
-  pipelines(projectId, { mergerequestId } = {}) {
+  pipelines(projectId, { mergerequestId }: { mergerequestId?: string } = {}) {
     const pId = encodeURIComponent(projectId);
     const mergeRequest = mergerequestId ? `merge_requests/${encodeURIComponent(mergerequestId)}` : '';
 

--- a/src/services/Projects.ts
+++ b/src/services/Projects.ts
@@ -1,3 +1,5 @@
+import Fs from 'fs';
+import Path from 'path';
 import { BaseService, RequestHelper } from '../infrastructure';
 import { validateEventOptions } from './Events';
 
@@ -106,13 +108,14 @@ class Projects extends BaseService {
 
   upload(projectId, filePath, { fileName = Path.basename(filePath) } = {}) {
     const pId = encodeURIComponent(projectId);
+    const file = Fs.readFileSync(filePath);
 
     return RequestHelper.post(
       this,
       `projects/${pId}/uploads`,
       {
         file: {
-          value: content,
+          value: file,
           options: {
             filename: fileName,
             contentType: 'application/octet-stream',

--- a/tsconfig-es5.dist.json
+++ b/tsconfig-es5.dist.json
@@ -2,6 +2,12 @@
   "extends": "./tsconfig.dist.json",
   "compilerOptions": {
     "target": "es5",
-    "outDir": "dist/es5"
+    "outDir": "dist/es5",
+    "lib": [
+      "dom",
+      "es5",
+      "scripthost",
+      "es2015.promise"
+    ],
   }
 }

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es6",
     "strict": false,
     "strictPropertyInitialization": false,
     "noUnusedParameters": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
#137, #89
* change target for modern env from es2017 to es6 (async/await should be transpiled to downlevel js)
* import correct 'wait' fn
* export 'wait'
* fix src/services/Projects.ts (likely was broken after wrong conflict resolution)