### PR TITLE
eslint does not like CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto
+*.js eol=lf
+*.ts eol=lf


### PR DESCRIPTION
fix working tree with
```
git rm --cached -r .
git reset --hard
```

```
C:\Users\josep\code\node-gitlab\test\tests\services\PushRule.js
   1:41  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   2:1   error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   3:29  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   4:99  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   5:3   warning  Disabled test                                    jest/no-disabled-tests
   5:65  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   6:35  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   7:35  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   8:48  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   9:8   error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  10:24  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  11:20  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  12:26  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  13:7   error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  14:53  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  15:1   error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  16:43  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  17:44  error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  18:6   error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
  19:4   error    Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style

✖ 3716 problems (3715 errors, 1 warning)
  3715 errors and 0 warnings potentially fixable with the `--fix` option
```