### PR TITLE
Fix typo in PagesDomains all() method

### DIFF
--- a/src/services/PagesDomains.js
+++ b/src/services/PagesDomains.js
@@ -4,7 +4,7 @@ class PagesDomains extends BaseService {
   all({ projectId } = {}) {
     const url = projectId ? `projects/${encodeURIComponent(projectId)}/` : '';
 
-    return RequestHelper.get(this, `${url}page/domains`);
+    return RequestHelper.get(this, `${url}pages/domains`);
   }
 
   create(projectId, domain, options) {


### PR DESCRIPTION
Updated URL to point to correct endpoint

Correct endpoint is: `GET /pages/domains` and `GET /projects/:id/pages/domains`

See relevant API doc here:
[https://docs.gitlab.com/ee/api/pages_domains.html](https://docs.gitlab.com/ee/api/pages_domains.html)