### PR TITLE
Added user snippets API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ NotificationSettings
 PagesDomains
 Search
 SidekiqMetrics
+Snippets
 SystemHooks
 Version
 Wikis

--- a/src/services/Snippets.ts
+++ b/src/services/Snippets.ts
@@ -1,0 +1,53 @@
+import { BaseService, RequestHelper } from '../infrastructure';
+
+class Snippets extends BaseService {
+  all(options = {}) {
+    return RequestHelper.get(this, `snippets`, options);
+  }
+
+  allPublic(options = {}) {
+    return RequestHelper.get(this, `snippets/public`, options);
+  }
+
+  content(snippetId) {
+    const sId = encodeURIComponent(snippetId);
+
+    return RequestHelper.get(this, `snippets/${sId}/raw`);
+  }
+
+  create(title, fileName, content, visibility, options = {}) {
+    return RequestHelper.post(this, `snippets`, {
+      title,
+      fileName,
+      content,
+      visibility,
+      ...options,
+    });
+  }
+
+  edit(snippetId, options) {
+    const sId = encodeURIComponent(snippetId);
+
+    return RequestHelper.put(this, `snippets/${sId}`, options);
+  }
+
+  remove(snippetId) {
+    const sId = encodeURIComponent(snippetId);
+
+    return RequestHelper.delete(this, `snippets/${sId}`);
+  }
+
+  show(snippetId) {
+    const sId = encodeURIComponent(snippetId);
+
+    return RequestHelper.get(this, `snippets/${sId}`);
+  }
+
+  userAgentDetails(snippetId) {
+    const sId = encodeURIComponent(snippetId);
+
+    return RequestHelper.get(this, `snippets/${sId}/user_agent_detail`);
+  }
+}
+
+export default Snippets;

--- a/src/services/Snippets.ts
+++ b/src/services/Snippets.ts
@@ -13,7 +13,7 @@ class Snippets extends BaseService {
   }
 
   create(title, fileName, content, visibility, options = {}) {
-    return RequestHelper.post(this, `snippets`, {
+    return RequestHelper.post(this, 'snippets', {
       title,
       fileName,
       content,

--- a/src/services/Snippets.ts
+++ b/src/services/Snippets.ts
@@ -1,12 +1,9 @@
 import { BaseService, RequestHelper } from '../infrastructure';
 
 class Snippets extends BaseService {
-  all(options = {}) {
-    return RequestHelper.get(this, `snippets`, options);
-  }
-
-  allPublic(options = {}) {
-    return RequestHelper.get(this, `snippets/public`, options);
+  all(options = { public: false }) {
+    const url = options.public ? 'snippets/public' : 'snippets';
+    return RequestHelper.get(this, url, options);
   }
 
   content(snippetId) {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -82,6 +82,7 @@ export { default as NotificationSettings } from './NotificationSettings';
 export { default as PagesDomains } from './PagesDomains';
 export { default as Search } from './Search';
 export { default as SidekiqMetrics } from './SidekiqMetrics';
+export { default as Snippets } from './Snippets';
 export { default as SystemHooks } from './SystemHooks';
 export { default as Version } from './Version';
 export { default as Wikis } from './Wikis';

--- a/test/tests/services/Snippets.ts
+++ b/test/tests/services/Snippets.ts
@@ -1,0 +1,15 @@
+import { Snippets } from '../../../src';
+
+describe('Snippets', () => {
+  it('should create snippet', async () => {
+    const service = new Snippets({
+      url: process.env.GITLAB_URL,
+      token: process.env.PERSONAL_ACCESS_TOKEN,
+    });
+
+    const result = await service.create('This is a snippet', 'test.txt', 'Hello world', 'internal', { 'description': 'Hello World snippet' });
+
+    expect(result).toBeInstanceOf(Object);
+    expect(result.title).toEqual('This is a snippet');
+  });
+});


### PR DESCRIPTION
User snippets do not belong to a specific project and have a [different API resource](https://docs.gitlab.com/ee/api/snippets.html)  than the project snippets.