### PR TITLE
Improve jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
 	preset: 'ts-jest',
 
 	testEnvironment: 'node',
-	testRegex: '(/__tests__/.*|/tests/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
+	testRegex: 'test/tests/.*\\.ts$',
 	testMatch: null,
 	testURL: 'http://localhost/',
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:bundles": "jest test/tests/bundles",
     "test:infrastructure": "jest test/tests/infrastructure",
     "test:services": "jest test/tests/services",
-    "test": "jest --debug && codecov",
+    "test": "jest --debug --runInBand && codecov",
     "prepublishOnly": "npm run build",
     "semantic-release": "semantic-release"
   },


### PR DESCRIPTION
* Specify folder for tests, otherwise it runs tests from dist/ if any
* pass `--runInBand` to speed up tests execution (jest compiles project as
many times as many threads it uses). MBP 2017, cold cache:

--runInBand
	11.31s user 1.91s system 83% cpu 15.914 total

8 workers
	76.28s user 8.49s system 309% cpu 27.401 total