### PR TITLE
Fix array syntax to `'brackets'`

### DIFF
--- a/src/infrastructure/RequestHelper.ts
+++ b/src/infrastructure/RequestHelper.ts
@@ -10,6 +10,7 @@ interface RequestParametersInput {
   json?: boolean;
   body?: Object;
   qs?: Object;
+  qsStringifyOptions? : Object;
   formData?: temporaryAny;
   resolveWithFullResponse?: boolean;
   rejectUnauthorized?: boolean;
@@ -44,9 +45,10 @@ function defaultRequest(
   if (qs) {
     if (useXMLHttpRequest) {
       // The xhr package doesn't have a way of passing in a qs object until v3
-      params.url = URLJoin(params.url, `?${QS.stringify(Humps.decamelizeKeys(qs))}`);
+      params.url = URLJoin(params.url, `?${QS.stringify(Humps.decamelizeKeys(qs), { arrayFormat: 'brackets' })}`);
     } else {
       params.qs = Humps.decamelizeKeys(qs);
+      params.qsStringifyOptions = { arrayFormat: 'brackets' };
     }
   }
 


### PR DESCRIPTION
At the moment arrays, like e.g. `iids` in issues are serialized wrong. For example:

```
Issues.all({projectId: 123, iids: [10, 11, 12]})
```
will be serialized as
```
/projects/123/issues?iids[0]=10&iids[1]=11&iids[2]=12
```
when they should be serialized as
```
/projects/123/issues?iids[]=10&iids[]=11&iids[]=12
```

- [GitLab API documentation on arrays](https://docs.gitlab.com/ee/api/#array)