### PR TITLE
Emitting Typings while build, removed Node Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 dist
 coverage
+.idea

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "gitlab",
   "version": "4.2.1",
   "description": "Full NodeJS implementation of the GitLab API. Supports Promises, Async/Await.",
-  "main": "dist/latest/index.js",
+  "main": "dist/es5/index.js",
+  "modules": "dist/latest/index.js",
+  "types": "dist/latest/index.d.ts",
   "engines": {
     "node": ">=8.9.0"
   },

--- a/src/infrastructure/XMLHttpRequester.ts
+++ b/src/infrastructure/XMLHttpRequester.ts
@@ -1,5 +1,4 @@
 import { StatusCodeError } from 'request-promise-core/errors';
-import { promisify } from 'util';
 import XHR, { XhrUriConfig, XhrUrlConfig } from 'xhr';
 import { wait } from './RequestHelper';
 
@@ -22,7 +21,17 @@ interface XhrConfgExtraParams {
 }
 
 function promisifyWithRetry<F extends Function>(fn: F): XhrInstancePromisified {
-  const promisifiedFn = promisify(fn);
+
+  const promisifiedFn = (...args: any[]) => new Promise<any>((resolve, reject) => {
+    fn(...args, (err:any, data:any) => {
+
+      if (err) {
+        reject(err);
+      }
+
+      resolve(data);
+    });
+  });
 
   return async function getResponse(
     opts: XhrUriConfig & XhrConfgExtraParams | XhrUrlConfig & XhrConfgExtraParams,

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "target": "es6",
+    "declaration": true,
     "strict": false,
     "strictPropertyInitialization": false,
     "strictNullChecks": false,


### PR DESCRIPTION
Hey,

I changed some configuration for your builds and fixed some old dependencies, so this lib can be used in the browser and typings are emitted.

Let me know, what you think.

Best Regards, 
   Johann