### PR TITLE
Prevent mangled URL when redirected to https

### DIFF
--- a/src/infrastructure/RequestHelper.ts
+++ b/src/infrastructure/RequestHelper.ts
@@ -103,6 +103,9 @@ async function getPaginated(
   // If not looking for a singular page and still under the max pages limit
   // AND their is a next page, paginate
   if (!queryOptions.page && underMaxPageLimit && links.next) {
+    // If redirected from http:// to https://, need to update service.url to avoid url inception
+    if (service.url.slice(0,5) === 'http:' && links.next.url.slice(0,5) === 'https')
+      service.url = service.url.replace('http:', 'https:');
     more = await getPaginated(service, links.next.url.replace(service.url, ''), options);
     data = [...response.body, ...more];
   } else {

--- a/src/infrastructure/RequestHelper.ts
+++ b/src/infrastructure/RequestHelper.ts
@@ -104,8 +104,10 @@ async function getPaginated(
   // AND their is a next page, paginate
   if (!queryOptions.page && underMaxPageLimit && links.next) {
     // If redirected from http:// to https://, need to update service.url to avoid url inception
-    if (service.url.slice(0,5) === 'http:' && links.next.url.slice(0,5) === 'https')
+    if (service.url.slice(0,5) === 'http:' && links.next.url.slice(0,5) === 'https') {
       service.url = service.url.replace('http:', 'https:');
+    }
+    
     more = await getPaginated(service, links.next.url.replace(service.url, ''), options);
     data = [...response.body, ...more];
   } else {

--- a/src/infrastructure/RequestHelper.ts
+++ b/src/infrastructure/RequestHelper.ts
@@ -104,10 +104,9 @@ async function getPaginated(
   // AND their is a next page, paginate
   if (!queryOptions.page && underMaxPageLimit && links.next) {
     // If redirected from http:// to https://, need to update service.url to avoid url inception
-    if (service.url.slice(0,5) === 'http:' && links.next.url.slice(0,5) === 'https') {
+    if (service.url.slice(0, 5) === 'http:' && links.next.url.slice(0, 5) === 'https') {
       service.url = service.url.replace('http:', 'https:');
     }
-    
     more = await getPaginated(service, links.next.url.replace(service.url, ''), options);
     data = [...response.body, ...more];
   } else {


### PR DESCRIPTION
When starting with an 'http' URL for a Gitlab instance that redirects to 'https', the URL is getting mangled as the 'replace' call is looking for 'https://gitlab.example/api/v4/projects' when the service.url is 'http://gitlab.example/api/v4/projects'. You end up with something like "http://gitlab.example/api/v4/projects/https://gitlab.example/api/v4/projects/" in subsequent steps.