### PR TITLE
fix: modify `Mapper` to get correct service instance

### DIFF
--- a/src/services/Branches.ts
+++ b/src/services/Branches.ts
@@ -2,7 +2,7 @@ import { BaseService, RequestHelper } from '../infrastructure';
 import { BaseRequestOptions, PaginatedRequestOptions, Sudo, ProjectId } from '../../types/types';
 
 class Branches extends BaseService {
-  all(projectId: ProjectId, options: { search: string } & PaginatedRequestOptions) {
+  all(projectId: ProjectId, options?: { search?: string } & PaginatedRequestOptions) {
     const pId = encodeURIComponent(projectId);
 
     return RequestHelper.get(this, `projects/${pId}/repository/branches`, options);

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -46,7 +46,7 @@ export interface Constructor {
 }
 
 export type Mapper<T extends { [name: string]: Constructor }, P extends keyof T> = {
-  [name in P]: InstanceType<T[P]>
+  [name in P]: InstanceType<T[name]>
 };
 
 export interface Bundle<T extends { [name: string]: Constructor }, P extends keyof T> {


### PR DESCRIPTION
```diff
-  [name in P]: InstanceType<T[P]>
+  [name in P]: InstanceType<T[name]>
```

With `T[P]` Typescript cannot infer the correct instance type.