### PR TITLE
Add maxPages to RequestOptions

### DIFF
--- a/src/infrastructure/RequestHelper.ts
+++ b/src/infrastructure/RequestHelper.ts
@@ -188,6 +188,7 @@ export interface RequestOptions {
   public?: boolean;
   text?: string;
   token?: string;
+  maxPages?: number;
 }
 
 class RequestHelper {


### PR DESCRIPTION
This field is used during pagination requestions for `all` functions.