### PR TITLE
Add function to erase artifacts only

### DIFF
--- a/src/services/Jobs.ts
+++ b/src/services/Jobs.ts
@@ -61,6 +61,12 @@ class Jobs extends BaseService {
     return RequestHelper.post(this, `projects/${pId}/jobs/${jId}/erase`);
   }
 
+  eraseArtifacts(projectId: ProjectId, jobId: JobId) {
+    const [pId, jId] = [projectId, jobId].map(encodeURIComponent);
+
+    return RequestHelper.delete(this, `projects/${pId}/jobs/${jId}/artifacts`);
+  }
+
   keepArtifacts(projectId: ProjectId, jobId: JobId) {
     const [pId, jId] = [projectId, jobId].map(encodeURIComponent);
 


### PR DESCRIPTION
It could be useful to erase only the artefacts associated to a job, not the whole job.