### PR TITLE
refactor(RepositoryFiles): Missing a required argument from the function headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## [5.0.2](https://github.com/jdalrymple/node-gitlab/compare/5.0.1...5.0.2) (2019-05-31)
 
-
 ### Bug Fixes
 
-* Properly handling the response bodies returned from gitlab ([881b87b](https://github.com/jdalrymple/node-gitlab/commit/881b87b)), closes [#320](https://github.com/jdalrymple/node-gitlab/issues/320)
+- Properly handling the response bodies returned from gitlab ([881b87b](https://github.com/jdalrymple/node-gitlab/commit/881b87b)), closes [#320](https://github.com/jdalrymple/node-gitlab/issues/320)
 
 ## [5.0.1](https://github.com/jdalrymple/node-gitlab/compare/5.0.0...5.0.1) (2019-05-26)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3082,7 +3082,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3103,12 +3104,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3123,17 +3126,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3250,7 +3256,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3262,6 +3269,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3276,6 +3284,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3283,12 +3292,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3307,6 +3318,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3387,7 +3399,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3399,6 +3412,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3484,7 +3498,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3520,6 +3535,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3539,6 +3555,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3582,12 +3599,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/services/RepositoryFiles.ts
+++ b/src/services/RepositoryFiles.ts
@@ -37,7 +37,13 @@ class RepositoryFiles extends BaseService {
     });
   }
 
-  remove(projectId: ProjectId, filePath: string, branch: string, commitMessage: string, options?: BaseRequestOptions) {
+  remove(
+    projectId: ProjectId,
+    filePath: string,
+    branch: string,
+    commitMessage: string,
+    options?: BaseRequestOptions,
+  ) {
     const [pId, path] = [projectId, filePath].map(encodeURIComponent);
 
     return RequestHelper.del(this, `projects/${pId}/repository/files/${path}`, {

--- a/src/services/RepositoryFiles.ts
+++ b/src/services/RepositoryFiles.ts
@@ -6,6 +6,7 @@ class RepositoryFiles extends BaseService {
     filePath: string,
     branch: string,
     content: string,
+    commitMessage: string,
     options?: BaseRequestOptions,
   ) {
     const [pId, path] = [projectId, filePath].map(encodeURIComponent);
@@ -13,6 +14,7 @@ class RepositoryFiles extends BaseService {
     return RequestHelper.post(this, `projects/${pId}/repository/files/${path}`, {
       branch,
       content,
+      commitMessage,
       ...options,
     });
   }
@@ -22,6 +24,7 @@ class RepositoryFiles extends BaseService {
     filePath: string,
     branch: string,
     content: string,
+    commitMessage: string,
     options?: BaseRequestOptions,
   ) {
     const [pId, path] = [projectId, filePath].map(encodeURIComponent);
@@ -29,15 +32,17 @@ class RepositoryFiles extends BaseService {
     return RequestHelper.put(this, `projects/${pId}/repository/files/${path}`, {
       branch,
       content,
+      commitMessage,
       ...options,
     });
   }
 
-  remove(projectId: ProjectId, filePath: string, branch: string, options?: BaseRequestOptions) {
+  remove(projectId: ProjectId, filePath: string, branch: string, commitMessage: string, options?: BaseRequestOptions) {
     const [pId, path] = [projectId, filePath].map(encodeURIComponent);
 
     return RequestHelper.del(this, `projects/${pId}/repository/files/${path}`, {
       branch,
+      commitMessage,
       ...options,
     });
   }


### PR DESCRIPTION
Commit messages are required for most of the RepositoryFile functions and was missing.

BREAKING CHANGE: create, edit and remove functions now require the commitMessage function argument