### PR TITLE
fix: Include path to typings dir in src/index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## [5.0.2](https://github.com/jdalrymple/node-gitlab/compare/5.0.1...5.0.2) (2019-05-31)
 
-
 ### Bug Fixes
 
-* Properly handling the response bodies returned from gitlab ([881b87b](https://github.com/jdalrymple/node-gitlab/commit/881b87b)), closes [#320](https://github.com/jdalrymple/node-gitlab/issues/320)
+- Properly handling the response bodies returned from gitlab ([881b87b](https://github.com/jdalrymple/node-gitlab/commit/881b87b)), closes [#320](https://github.com/jdalrymple/node-gitlab/issues/320)
 
 ## [5.0.1](https://github.com/jdalrymple/node-gitlab/compare/5.0.0...5.0.1) (2019-05-26)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference types="../typings" />
 import { shim } from 'universal-url';
 
 // Add URL shim


### PR DESCRIPTION
Aimed to fix #321 

Reference in index.ts includes typings/*.d.ts files to the build

FYI: Encountered the following error while trying to build project with `gitlab` as a dependency.
```bash
....
node_modules/gitlab/dist/index.d.ts:26:38 - error TS2304: Cannot find name 'Bundle'.

26 export declare const ProjectsBundle: Bundle<{
                                        ~~~~~~

node_modules/gitlab/dist/index.d.ts:69:30 - error TS2304: Cannot find name 'Bundle'.

69 export declare const Gitlab: Bundle<typeof APIServices, "Groups" | "GroupAccessRequests" | "GroupBadges" | "GroupCustomAttributes" | "GroupIssueBoards" | "GroupMembers" | "GroupMilestones" | "GroupProjects" | "GroupVariables" | "Epics" | "EpicIssues" | "EpicNotes" | "EpicDiscussions" | "Users" | "UserCustomAttributes" | "UserEmails" | "UserImpersonationTokens" | "UserKeys" | "UserGPGKeys" | "Branches" | "Commits" | "CommitDiscussions" | "DeployKeys" | "Deployments" | "Environments" | "Issues" | "IssueAwardEmojis" | "IssueNotes" | "IssueDiscussions" | "Jobs" | "Labels" | "MergeRequests" | "MergeRequestAwardEmojis" | "MergeRequestDiscussions" | "MergeRequestNotes" | "Pipelines" | "PipelineSchedules" | "PipelineScheduleVariables" | "Projects" | "ProjectAccessRequests" | "ProjectBadges" | "ProjectCustomAttributes" | "ProjectImportExport" | "ProjectIssueBoards" | "ProjectHooks" | "ProjectMembers" | "ProjectMilestones" | "ProjectSnippets" | "ProjectSnippetNotes" | "ProjectSnippetDiscussions" | "ProjectSnippetAwardEmojis" | "ProtectedBranches" | "ProtectedTags" | "ProjectVariables" | "Repositories" | "RepositoryFiles" | "Runners" | "Services" | "Tags" | "Triggers" | "Todos" | "PushRule" | "ApplicationSettings" | "BroadcastMessages" | "Events" | "FeatureFlags" | "GeoNodes" | "GitignoreTemplates" | "GitLabCIYMLTemplates" | "Keys" | "Licence" | "LicenceTemplates" | "Lint" | "Namespaces" | "NotificationSettings" | "Markdown" | "PagesDomains" | "Search" | "SidekiqMetrics" | "Snippets" | "SystemHooks" | "Version" | "Wikis">;
                                ~~~~~~


Found 1039 errors.
```