### PR TITLE
feat: Add configurable request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ const api = new Gitlab({
   version = 'v4',           //API Version ID. Optional, Default: v4
   camelize = false,         //Response Key Camelize. Camelizes all response body keys. Optional, Default: false
   requester = KyRequester,  //Request Library Wrapper. Optional, Default: Currently wraps Ky.
+  requestTimeout = 300000   //Request Library Timeout. Optional, Default: 300,000 milliseconds.
 });
 ```
 

--- a/src/infrastructure/BaseService.ts
+++ b/src/infrastructure/BaseService.ts
@@ -3,6 +3,7 @@ import { KyRequester } from './KyRequester';
 export class BaseService {
   public readonly url: string;
   public readonly requester: Requester;
+  public readonly requestTimeout: number;
   public readonly headers: { [header: string]: string };
   public readonly camelize: boolean;
   public readonly rejectUnauthorized: boolean;
@@ -18,12 +19,14 @@ export class BaseService {
     camelize = false,
     rejectUnauthorized = true,
     requester = KyRequester,
+    requestTimeout = 300000
   }: BaseServiceOptions) {
     this.url = [host, 'api', version, url].join('/');
     this.headers = {};
     this.rejectUnauthorized = rejectUnauthorized;
     this.camelize = camelize;
     this.requester = requester;
+    this.requestTimeout = requestTimeout;
 
     // Handle auth tokens
     if (oauthToken) this.headers.authorization = `Bearer ${oauthToken}`;

--- a/src/infrastructure/KyRequester.ts
+++ b/src/infrastructure/KyRequester.ts
@@ -23,7 +23,7 @@ function defaultRequest(service: any, { body, query, sudo, method }) {
   if (sudo) headers.append('sudo', `${sudo}`);
 
   return {
-      timeout: 300000,
+      timeout: service.requestTimeout,
       headers,
       method: (method === 'stream') ? 'get' : method,
       onProgress: (method === 'stream') ? () => {} : undefined,

--- a/test/unit/services/Pipelines.ts
+++ b/test/unit/services/Pipelines.ts
@@ -22,6 +22,7 @@ let service: Pipelines;
 beforeEach(() => {
   service = new Pipelines({
     token: 'abcdefg',
+    requestTimeout: 3000,
   });
 });
 
@@ -31,6 +32,7 @@ describe('Instantiating Pipelines service', () => {
     expect(service.url).toBeDefined();
     expect(service.rejectUnauthorized).toBeTruthy();
     expect(service.headers).toMatchObject({ 'private-token': 'abcdefg' });
+    expect(service.requestTimeout).toBe(3000);
   });
 });
 

--- a/typings/infrastructure.d.ts
+++ b/typings/infrastructure.d.ts
@@ -34,6 +34,7 @@ interface BaseServiceOptions extends Sudo {
   rejectUnauthorized?: boolean;
   camelize?: boolean;
   requester?: Requester;
+  requestTimeout?: number;
 }
 
 // RequestHelper


### PR DESCRIPTION
When making requests against large instances (say get all public projects of gitlab.com) the calls appear to hang, but in reality it's just that the request timeout is set to 300 seconds. This PR adds the ability for the client to configure the timeout (default is still 300 seconds) so that we can timeout for clients that need to do so.