### PR TITLE
fix: PushRules were missing from the ProjectBundle export and the REA…

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ ProjectSnippetAwardEmojis
 ProtectedBranches
 ProtectedTags
 ProjectVariables
+PushRules
 Releases
 ReleaseLinks
 Repositories
@@ -239,6 +240,7 @@ ProjectSnippetAwardEmojis
 ProtectedBranches
 ProtectedTags
 ProjectVariables
+PushRules
 Repositories
 RepositoryFiles
 Runners

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export const ProjectsBundle = bundler({
   ProtectedBranches: APIServices.ProtectedBranches,
   ProtectedTags: APIServices.ProtectedTags,
   ProjectVariables: APIServices.ProjectVariables,
+  PushRules: APIServices.PushRules,
   Releases: APIServices.Releases,
   ReleaseLinks: APIServices.ReleaseLinks,
   Repositories: APIServices.Repositories,

--- a/src/services/PushRules.ts
+++ b/src/services/PushRules.ts
@@ -1,7 +1,7 @@
 import { BaseService, RequestHelper, BaseRequestOptions, Sudo } from '../infrastructure';
 import { ProjectId } from '.';
 
-class PushRule extends BaseService {
+class PushRules extends BaseService {
   create(projectId: ProjectId, options?: BaseRequestOptions) {
     const pId = encodeURIComponent(projectId);
 
@@ -36,4 +36,4 @@ class PushRule extends BaseService {
   }
 }
 
-export default PushRule;
+export default PushRules;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -58,6 +58,7 @@ export { default as ProjectSnippetAwardEmojis } from './ProjectSnippetAwardEmoji
 export { default as ProtectedBranches } from './ProtectedBranches';
 export { default as ProtectedTags } from './ProtectedTags';
 export { default as ProjectVariables } from './ProjectVariables';
+export { default as PushRules } from './PushRules';
 export { default as Releases } from './Releases';
 export { default as ReleaseLinks } from './ReleaseLinks';
 export { default as Repositories } from './Repositories';
@@ -67,7 +68,6 @@ export { default as Services } from './Services';
 export { default as Tags } from './Tags';
 export { default as Todos } from './Todos';
 export { default as Triggers } from './Triggers';
-export { default as PushRule } from './PushRule';
 
 // General
 export { default as ApplicationSettings } from './ApplicationSettings';

--- a/test/integration/services/PushRules.ts
+++ b/test/integration/services/PushRules.ts
@@ -1,9 +1,9 @@
-import { PushRule } from '../../../dist';
+import { PushRules } from '../../../dist';
 
-describe('PushRule.edit', () => {
+describe('PushRules.edit', () => {
   // the feature is not available for CE users https://gitlab.com/gitlab-org/gitlab-ee/issues/3825
   xit('should create or edit push rule on upsert', async () => {
-    const service = new PushRule({
+    const service = new PushRules({
       host: process.env.GITLAB_URL,
       token: process.env.PERSONAL_ACCESS_TOKEN,
     });


### PR DESCRIPTION
…DME. #373

BREAKING CHANGE: PushRule export was renamed to PushRules to match the plurality of the export names