### PR TITLE
feat: Adding missing endpoints for deploy keys #373

### DIFF
--- a/src/services/DeployKeys.ts
+++ b/src/services/DeployKeys.ts
@@ -1,4 +1,10 @@
-import { BaseService, RequestHelper, Sudo, BaseRequestOptions, PaginatedRequestOptions } from '../infrastructure';
+import {
+  BaseService,
+  RequestHelper,
+  Sudo,
+  BaseRequestOptions,
+  PaginatedRequestOptions,
+} from '../infrastructure';
 import { ProjectId, KeyId } from '.';
 
 class DeployKeys extends BaseService {
@@ -8,10 +14,7 @@ class DeployKeys extends BaseService {
     return RequestHelper.post(this, `projects/${pId}/deploy_keys`, options);
   }
 
-  all({
-    projectId,
-    ...options
-  }:{ projectId?: ProjectId } & PaginatedRequestOptions) {
+  all({ projectId, ...options }: { projectId?: ProjectId } & PaginatedRequestOptions) {
     let url;
 
     if (projectId) {
@@ -23,7 +26,7 @@ class DeployKeys extends BaseService {
     return RequestHelper.get(this, url, options);
   }
 
-  edit(projectId: ProjectId, keyId: KeyId, options?:BaseRequestOptions) {
+  edit(projectId: ProjectId, keyId: KeyId, options?: BaseRequestOptions) {
     const [pId, kId] = [projectId, keyId].map(encodeURIComponent);
 
     return RequestHelper.put(this, `projects/${pId}/deploy_keys/${kId}`, options);
@@ -35,7 +38,7 @@ class DeployKeys extends BaseService {
     return RequestHelper.post(this, `projects/${pId}/deploy_keys/${kId}/enable`, options);
   }
 
-  remove(projectId: ProjectId, keyId: KeyId, options?:Sudo) {
+  remove(projectId: ProjectId, keyId: KeyId, options?: Sudo) {
     const [pId, kId] = [projectId, keyId].map(encodeURIComponent);
 
     return RequestHelper.del(this, `projects/${pId}/deploy_keys/${kId}`, options);

--- a/src/services/DeployKeys.ts
+++ b/src/services/DeployKeys.ts
@@ -1,4 +1,4 @@
-import { BaseService, RequestHelper, Sudo, PaginatedRequestOptions } from '../infrastructure';
+import { BaseService, RequestHelper, Sudo, BaseRequestOptions, PaginatedRequestOptions } from '../infrastructure';
 import { ProjectId, KeyId } from '.';
 
 class DeployKeys extends BaseService {
@@ -8,22 +8,43 @@ class DeployKeys extends BaseService {
     return RequestHelper.post(this, `projects/${pId}/deploy_keys`, options);
   }
 
-  all(projectId: ProjectId, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
+  all({
+    projectId,
+    ...options
+  }:{ projectId?: ProjectId } & PaginatedRequestOptions) {
+    let url;
 
-    return RequestHelper.get(this, `projects/${pId}/deploy_keys`, options);
+    if (projectId) {
+      url = `projects/${encodeURIComponent(projectId)}/deploy_keys`;
+    } else {
+      url = 'deploy_keys';
+    }
+
+    return RequestHelper.get(this, url, options);
   }
 
-  show(projectId: ProjectId, keyId: KeyId, options?: Sudo) {
+  edit(projectId: ProjectId, keyId: KeyId, options?:BaseRequestOptions) {
     const [pId, kId] = [projectId, keyId].map(encodeURIComponent);
 
-    return RequestHelper.get(this, `projects/${pId}/deploy_keys/${kId}`, options);
+    return RequestHelper.put(this, `projects/${pId}/deploy_keys/${kId}`, options);
   }
 
   enable(projectId: ProjectId, keyId: KeyId, options?: Sudo) {
     const [pId, kId] = [projectId, keyId].map(encodeURIComponent);
 
     return RequestHelper.post(this, `projects/${pId}/deploy_keys/${kId}/enable`, options);
+  }
+
+  remove(projectId: ProjectId, keyId: KeyId, options?:Sudo) {
+    const [pId, kId] = [projectId, keyId].map(encodeURIComponent);
+
+    return RequestHelper.del(this, `projects/${pId}/deploy_keys/${kId}`, options);
+  }
+
+  show(projectId: ProjectId, keyId: KeyId, options?: Sudo) {
+    const [pId, kId] = [projectId, keyId].map(encodeURIComponent);
+
+    return RequestHelper.get(this, `projects/${pId}/deploy_keys/${kId}`, options);
   }
 }
 


### PR DESCRIPTION
BREAKING CHANGE: all method now takes an optional object since projectId is no longer required. If no projectId is passed, the all method returns all deploy keys across all projects of the GitLab instance