### PR TITLE
fix: Accept any variables that begin with uppercase letters and inclu…

### DIFF
--- a/src/infrastructure/Utils.ts
+++ b/src/infrastructure/Utils.ts
@@ -1,4 +1,4 @@
-import { Constructor, Bundle } from ".";
+import { Constructor, Bundle } from '.';
 
 export function bundler<T extends { [name: string]: Constructor }, P extends keyof T>(services: T) {
   return (function Bundle(options?: any) {
@@ -9,5 +9,5 @@ export function bundler<T extends { [name: string]: Constructor }, P extends key
 }
 
 export function skipAllCaps(key, convert, options) {
-  return /^[A-Z0-9_]+$/.test(key) ? key : convert(key, options);
+  return /^([A-Z0-9])+_*/.test(key) ? key : convert(key, options);
 }


### PR DESCRIPTION
…de an underscore #254

This updated regex isn't foolproof. If the user decides to use lowercase variables, this will not work. Would beed to change the internal logic to allow for the skipping of the camelization.

closes: #254