### PR TITLE
chore: revert minimum node version back to 8.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript": "3.5.3"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=8.9.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Commit https://github.com/jdalrymple/node-gitlab/commit/3814790edadf2700609bf40b0ef7497302d79ff8 set minimum node version to `12.0.0` but it didn't really seem necessary or related to that particular change.

If the minimum node version needs to be raised, maybe it should be done in separate and discussed with the users?

Closes #422