### PR TITLE
Add type exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,3 +87,9 @@ export const ProjectsBundle = bundler({
 
 // All initialized
 export const Gitlab = bundler(APIServices);
+
+// Types
+export type UsersBundle = InstanceType<typeof UsersBundle>;
+export type GroupsBundle = InstanceType<typeof GroupsBundle>;
+export type ProjectsBundle = InstanceType<typeof ProjectsBundle>;
+export type Gitlab = InstanceType<typeof Gitlab>;

--- a/test/unit/bundles/Gitlab.ts
+++ b/test/unit/bundles/Gitlab.ts
@@ -5,7 +5,7 @@ const { Gitlab: GitlabCommon } = require('../../../src');
 
 describe('Instantiating All services', () => {
   it('should create a valid gitlab service object using import', async () => {
-    const bundle = new GitlabModule({
+    const bundle: GitlabModule = new GitlabModule({
       token: 'abcdefg',
     });
 

--- a/test/unit/bundles/GroupsBundle.ts
+++ b/test/unit/bundles/GroupsBundle.ts
@@ -2,7 +2,7 @@ import { GroupsBundle } from '../../../src';
 import * as Services from '../../../src/services';
 
 test('All the correct service keys are included in the groups bundle', async () => {
-  const bundle = new GroupsBundle({ token: 'test' });
+  const bundle: GroupsBundle = new GroupsBundle({ token: 'test' });
   const services = [
     'Groups',
     'GroupAccessRequests',

--- a/test/unit/bundles/ProjectsBundle.ts
+++ b/test/unit/bundles/ProjectsBundle.ts
@@ -2,7 +2,7 @@ import { ProjectsBundle } from '../../../src';
 import * as Services from '../../../src/services';
 
 test('All the correct service keys are included in the projects bundle', async () => {
-  const bundle = new ProjectsBundle({ token: 'test' });
+  const bundle: ProjectsBundle = new ProjectsBundle({ token: 'test' });
   const services = [
     'Branches',
     'Commits',

--- a/test/unit/bundles/UsersBundle.ts
+++ b/test/unit/bundles/UsersBundle.ts
@@ -2,7 +2,7 @@ import { UsersBundle } from '../../../src';
 import * as Services from '../../../src/services';
 
 test('All the correct service keys are included in the users bundle', async () => {
-  const bundle = new UsersBundle({ token: 'test' });
+  const bundle: UsersBundle = new UsersBundle({ token: 'test' });
   const services = [
     'Users',
     'UserEmails',


### PR DESCRIPTION
- Exports the types of `Gitlab`, `UsersBundle`, etc. using the built-in `InstanceType` defined as follows:
```typescript
/**
 * Obtain the return type of a constructor function type
 */
type InstanceType<T extends new (...args: any) => any> = T extends new (...args: any) => infer R ? R : any;
```
- Should resolve the missing type problem of https://github.com/jdalrymple/node-gitlab/issues/384
```typescript
import * as gitlab from 'gitlab'
const aaa = new gitlab.Gitlab({ host:'foo', token:'bar' });
const bbb : WHAT_AM_I??? = aaa;
```
- Not sure if this could break anything, just a suggestion ¯\_(ツ)_/¯