### PR TITLE
feat: Get Single Environment for a Project

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ To get this running locally rather than from your `node_modules` folder:
 $ git clone https://github.com/jdalrymple/node-gitlab.git
 $ cd node-gitlab
 $ npm install
-$ npm build
+$ npm run-script build
 ```
 
 And then inside whatever project you are using `node-gitlab` in you change your references to use that repo. In your package.json of that upstream project change:

--- a/src/core/services/Environments.ts
+++ b/src/core/services/Environments.ts
@@ -14,6 +14,12 @@ class Environments extends BaseService {
     return RequestHelper.get(this, `projects/${pId}/environments`, options);
   }
 
+  show(projectId: ProjectId, environmentId: EnvironmentId, options?: Sudo) {
+    const [pId, eId] = [projectId, environmentId].map(encodeURIComponent);
+
+    return RequestHelper.get(this, `projects/${pId}/environments/${eId}`, options);
+  }
+
   create(projectId: ProjectId, options?: BaseRequestOptions) {
     const pId = encodeURIComponent(projectId);
 


### PR DESCRIPTION
Found that the [Get Single Environment](https://docs.gitlab.com/ee/api/environments.html#get-a-specific-environment) endpoint was missing.  

Also found a little update that's needed in the readme for developing.  Guessing that was a change in `npm` somewhere along the line.