### PR TITLE
fix: removed "type": "module" from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,5 @@
     "test:integration": "jest test/integration -c=jest.config.json --detectOpenHandles",
     "test:unit": "jest test/unit --debug -c=jest.config.json"
   },
-  "type": "module",
   "types": "dist/index.d.ts"
 }


### PR DESCRIPTION
because main export still uses CommonJS modules, not ES6 import/export