### PR TITLE
feat: Add group label support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ GroupMembers
 GroupMilestones
 GroupProjects
 GroupVariables
+GroupLabels
 Epics
 EpicIssues
 EpicNotes
@@ -302,6 +303,7 @@ GroupMembers
 GroupMilestones
 GroupProjects
 GroupVariables
+GroupLabels
 Epics
 EpicIssues
 EpicNotes

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -20,6 +20,7 @@ export const GroupsBundle = bundler({
   GroupMilestones: APIServices.GroupMilestones,
   GroupProjects: APIServices.GroupProjects,
   GroupVariables: APIServices.GroupVariables,
+  GroupLabels: APIServices.GroupLabels,
   Epics: APIServices.Epics,
   EpicIssues: APIServices.EpicIssues,
   EpicNotes: APIServices.EpicNotes,

--- a/src/core/services/GroupLabels.ts
+++ b/src/core/services/GroupLabels.ts
@@ -1,0 +1,12 @@
+import { BaseService, PaginatedRequestOptions, RequestHelper } from '../infrastructure';
+import { GroupProjectId } from './index';
+
+class GroupLabels extends BaseService {
+  all(groupId: GroupProjectId, options?: PaginatedRequestOptions) {
+    const gId = encodeURIComponent(groupId);
+
+    return RequestHelper.get(this, `groups/${gId}/labels`, options);
+  }
+}
+
+export default GroupLabels;

--- a/src/core/services/GroupLabels.ts
+++ b/src/core/services/GroupLabels.ts
@@ -1,11 +1,9 @@
-import { BaseService, PaginatedRequestOptions, RequestHelper } from '../infrastructure';
-import { GroupProjectId } from './index';
+import { BaseServiceOptions } from '../infrastructure';
+import { ResourceLabels } from '../templates';
 
-class GroupLabels extends BaseService {
-  all(groupId: GroupProjectId, options?: PaginatedRequestOptions) {
-    const gId = encodeURIComponent(groupId);
-
-    return RequestHelper.get(this, `groups/${gId}/labels`, options);
+class GroupLabels extends ResourceLabels {
+  constructor(options: BaseServiceOptions) {
+    super('groups', options);
   }
 }
 

--- a/src/core/services/Labels.ts
+++ b/src/core/services/Labels.ts
@@ -1,51 +1,9 @@
-import {
-  BaseRequestOptions,
-  BaseService,
-  PaginatedRequestOptions,
-  RequestHelper,
-  Sudo,
-} from '../infrastructure';
-import { ProjectId, LabelId } from '.';
+import { BaseServiceOptions } from '../infrastructure';
+import { ResourceLabels } from '../templates';
 
-class Labels extends BaseService {
-  all(projectId: ProjectId, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.get(this, `projects/${pId}/labels`, options);
-  }
-
-  create(projectId: ProjectId, labelName: string, color: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.post(this, `projects/${pId}/labels`, {
-      name: labelName,
-      color,
-      ...options,
-    });
-  }
-
-  edit(projectId: ProjectId, labelName: string, options?: BaseRequestOptions) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.put(this, `projects/${pId}/labels`, { name: labelName, ...options });
-  }
-
-  remove(projectId: ProjectId, labelName: string, options?: Sudo) {
-    const pId = encodeURIComponent(projectId);
-
-    return RequestHelper.del(this, `projects/${pId}/labels`, { name: labelName, ...options });
-  }
-
-  subscribe(projectId: ProjectId, labelId: LabelId, options?: Sudo) {
-    const [pId, lId] = [projectId, labelId].map(encodeURIComponent);
-
-    return RequestHelper.post(this, `projects/${pId}/issues/${lId}/subscribe`, options);
-  }
-
-  unsubscribe(projectId: ProjectId, labelId: LabelId, options?: Sudo) {
-    const [pId, lId] = [projectId, labelId].map(encodeURIComponent);
-
-    return RequestHelper.del(this, `projects/${pId}/issues/${lId}/unsubscribe`, options);
+class Labels extends ResourceLabels {
+  constructor(options: BaseServiceOptions) {
+    super('projects', options);
   }
 }
 

--- a/src/core/services/Labels.ts
+++ b/src/core/services/Labels.ts
@@ -5,24 +5,13 @@ import {
   RequestHelper,
   Sudo,
 } from '../infrastructure';
-import { GroupId, ProjectId, LabelId } from '.';
+import { ProjectId, LabelId } from '.';
 
 class Labels extends BaseService {
-  all({
-    projectId,
-    groupId,
-    ...options
-  }: ({ projectId: ProjectId } | { groupId: GroupId } | {}) & PaginatedRequestOptions) {
-    let url;
-    
-    if (projectId) {
-      url = `projects/${encodeURIComponent(projectId)}/labels`;
-    }
-    else if (groupId) {
-      url = `groups/${encodeURIComponent(groupId)}/labels`;
-    }
+  all(projectId: ProjectId, options?: PaginatedRequestOptions) {
+    const pId = encodeURIComponent(projectId);
 
-    return RequestHelper.get(this, url, options);
+    return RequestHelper.get(this, `projects/${pId}/labels`, options);
   }
 
   create(projectId: ProjectId, labelName: string, color: string, options?: BaseRequestOptions) {

--- a/src/core/services/Labels.ts
+++ b/src/core/services/Labels.ts
@@ -5,13 +5,24 @@ import {
   RequestHelper,
   Sudo,
 } from '../infrastructure';
-import { ProjectId, LabelId } from '.';
+import { GroupId, ProjectId, LabelId } from '.';
 
 class Labels extends BaseService {
-  all(projectId: ProjectId, options?: PaginatedRequestOptions) {
-    const pId = encodeURIComponent(projectId);
+  all({
+    projectId,
+    groupId,
+    ...options
+  }: ({ projectId: ProjectId } | { groupId: GroupId } | {}) & PaginatedRequestOptions) {
+    let url;
+    
+    if (projectId) {
+      url = `projects/${encodeURIComponent(projectId)}/labels`;
+    }
+    else if (groupId) {
+      url = `groups/${encodeURIComponent(groupId)}/labels`;
+    }
 
-    return RequestHelper.get(this, `projects/${pId}/labels`, options);
+    return RequestHelper.get(this, url, options);
   }
 
   create(projectId: ProjectId, labelName: string, color: string, options?: BaseRequestOptions) {

--- a/src/core/services/index.ts
+++ b/src/core/services/index.ts
@@ -8,6 +8,7 @@ export { default as GroupMembers } from './GroupMembers';
 export { default as GroupMilestones } from './GroupMilestones';
 export { default as GroupProjects } from './GroupProjects';
 export { default as GroupVariables } from './GroupVariables';
+export { default as GroupLabels } from './GroupLabels';
 export { default as Epics } from './Epics';
 export { default as EpicIssues } from './EpicIssues';
 export { default as EpicNotes } from './EpicNotes';

--- a/src/core/templates/ResourceLabels.ts
+++ b/src/core/templates/ResourceLabels.ts
@@ -1,0 +1,57 @@
+import {
+  BaseRequestOptions,
+  BaseService,
+  BaseServiceOptions,
+  PaginatedRequestOptions,
+  RequestHelper,
+  Sudo,
+} from '../infrastructure';
+import { ResourceId, LabelId } from '../services';
+
+class ResourceLabels extends BaseService {
+  constructor(resourceType: string, options: BaseServiceOptions) {
+    super({ url: resourceType, ...options });
+  }
+
+  all(resourceId: ResourceId, options?: PaginatedRequestOptions) {
+    const rId = encodeURIComponent(resourceId);
+
+    return RequestHelper.get(this, `${rId}/labels`, options);
+  }
+
+  create(resourceId: ResourceId, labelName: string, color: string, options?: BaseRequestOptions) {
+    const rId = encodeURIComponent(resourceId);
+
+    return RequestHelper.post(this, `${rId}/labels`, {
+      name: labelName,
+      color,
+      ...options,
+    });
+  }
+
+  edit(resourceId: ResourceId, labelName: string, options?: BaseRequestOptions) {
+    const rId = encodeURIComponent(resourceId);
+
+    return RequestHelper.put(this, `${rId}/labels`, { name: labelName, ...options });
+  }
+
+  remove(resourceId: ResourceId, labelName: string, options?: Sudo) {
+    const rId = encodeURIComponent(resourceId);
+
+    return RequestHelper.del(this, `${rId}/labels`, { name: labelName, ...options });
+  }
+
+  subscribe(resourceId: ResourceId, labelId: LabelId, options?: Sudo) {
+    const [rId, lId] = [resourceId, labelId].map(encodeURIComponent);
+
+    return RequestHelper.post(this, `${rId}/issues/${lId}/subscribe`, options);
+  }
+
+  unsubscribe(resourceId: ResourceId, labelId: LabelId, options?: Sudo) {
+    const [rId, lId] = [resourceId, labelId].map(encodeURIComponent);
+
+    return RequestHelper.del(this, `${rId}/issues/${lId}/unsubscribe`, options);
+  }
+}
+
+export default ResourceLabels;

--- a/src/core/templates/index.ts
+++ b/src/core/templates/index.ts
@@ -4,6 +4,7 @@ export { default as ResourceBadges } from './ResourceBadges';
 export { default as ResourceCustomAttributes } from './ResourceCustomAttributes';
 export { default as ResourceDiscussions } from './ResourceDiscussions';
 export { default as ResourceIssueBoards } from './ResourceIssueBoards';
+export { default as ResourceLabels } from './ResourceLabels';
 export { default as ResourceMembers } from './ResourceMembers';
 export { default as ResourceMilestones } from './ResourceMilestones';
 export { default as ResourceNotes } from './ResourceNotes';

--- a/test/unit/bundles/GroupsBundle.ts
+++ b/test/unit/bundles/GroupsBundle.ts
@@ -13,6 +13,7 @@ test('All the correct service keys are included in the groups bundle', async () 
     'GroupMilestones',
     'GroupProjects',
     'GroupVariables',
+    'GroupLabels',
     'Epics',
     'EpicIssues',
     'EpicNotes',


### PR DESCRIPTION
~Note: This is a breaking change, since it changes the `Labels` function signature.~

~I'll let you update the package version as you wish.~

This PR adds a new `ResourceLabel` template then uses that to implement both `project` and `group` label services.

Closes: #454 