### PR TITLE
Replace GitHub links with GitLab official links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ GITLAB_HOST=http://example.com
 GITLAB_TOKEN=personaltoken
 ```
 
-This could be set globally or using a [.env](https://
-.com/motdotla/dotenv#readme) file in the project folder.
+This could be set globally or using a [.env](https://github.com/motdotla/dotenv#readme) file in the project folder.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 # node-gitlab
 
-🤖 [GitLab](https://github.com/gitlabhq/gitlabhq) API NodeJS library with full support of all the [Gitlab API](https://github.com/gitlabhq/gitlabhq/tree/master/doc/api) services.
+🤖 [GitLab](https://gitlab.com/gitlab-org/gitlab/) API NodeJS library with full support of all the [Gitlab API](https://gitlab.com/gitlab-org/gitlab/tree/master/doc/api) services.
 
 ## Table of Contents
 
@@ -106,11 +106,12 @@ GITLAB_HOST=http://example.com
 GITLAB_TOKEN=personaltoken
 ```
 
-This could be set globally or using a [.env](https://github.com/motdotla/dotenv#readme) file in the project folder.
+This could be set globally or using a [.env](https://
+.com/motdotla/dotenv#readme) file in the project folder.
 
 ## Docs
 
-Although there are the [official docs](https://github.com/gitlabhq/gitlabhq/tree/master/doc/api) for the API, there are some extra goodies offered by this package! After the 3.0.0 release, the next large project will be putting together proper documentation for these goodies [#39]! Stay tuned!!
+Although there are the [official docs](https://gitlab.com/gitlab-org/gitlab/tree/master/doc/api) for the API, there are some extra goodies offered by this package! After the 3.0.0 release, the next large project will be putting together proper documentation for these goodies [#39]! Stay tuned!!
 
 ### Supported APIs
 


### PR DESCRIPTION
GitLab's Official Repository has changed recently and is not mirrored to GitHub Properly. This Pull Request changes the API Links to the official GitLab Repo hosted on GitLab. That way people can get the most up to date details.